### PR TITLE
Do GitHub Pages Metadata better

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
   <!-- FONT AWESOME -->
   <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
   <!-- CUSTOM STYLES -->
-  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="{{ site.github.url }}/css/styles.css">
   <!-- TYPEKIT -->
   <script type="text/javascript" src="//use.typekit.net/elj4mla.js"></script>
   <script type="text/javascript">try{Typekit.load();}catch(e){}</script>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,7 +4,7 @@
         <h2>I build websites.</h2>
         <nav>
           <ul>
-            <li><a href="/">← Home</a></li>
+            <li><a href="{{ site.github.url }}/">← Home</a></li>
           </ul>
           <div style="clear:left;"></div>
         </nav>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <section id="portrait">
-    <div id="me"><img src="/img/portrait.png" alt="Troy Swanson"></div>
+    <div id="me"><img src="{{ site.github.url }}/img/portrait.png" alt="Troy Swanson"></div>
   </section>
   <section id="intro">
     {{ content }}
@@ -33,7 +33,7 @@
     <dl>
       {% for post in site.posts %}
       <dt><time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time></dt>
-      <dd><a href="{{ post.url }}">{{ post.title }}</a></dd>
+      <dd><a href="{{ site.github.url}}{{ post.url }}">{{ post.title }}</a></dd>
       {% endfor %}
     </dl>
   </section>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@
   <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
   <meta property="article:author" content="https://www.facebook.com/gerphimum">
   <meta property="article:section" content="developer">
-  <meta property="og:url" content="{{ site.github.url }}/{{ page.url }}">
+  <meta property="og:url" content="{{ site.github.url }}{{ page.url }}">
   <meta property="og:type" content="article">
   <meta property="og:title" content="{{ page.title }}">
   <meta property="og:locale" content="en_US">
@@ -21,11 +21,11 @@
       {% include sidebar.html %}
     </div>
     <div class="pure-u-3-4">
-      <article vocab="http://schema.org/" typeof="BlogPosting" resource="{{ page.url }}">
+      <article vocab="http://schema.org/" typeof="BlogPosting" resource="{{ site.github.url }}{{ page.url }}">
         <h1 property="name">{{ page.title }}</h1>
         <ul class="meta">
           <li class="pubdate"><time property="datePublished" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date_to_string }}</time></li>
-          <li class="permalink"><a property="url" href="{{ site.github.url }}/{{ page.url }}" title="Permalink">∞</a></li>
+          <li class="permalink"><a property="url" href="{{ site.github.url }}{{ page.url }}" title="Permalink">∞</a></li>
         </ul>
         <div class="body" property="articleBody">
           {{ content }}


### PR DESCRIPTION
Inspired by jekyll/jekyll#2914, I discovered some spots where I was implementing GitHub Pages Metadata in a pretty janky way. This converts all references to URLs on the site to absolute links, and fixes some instances that have double slashes in the URL.
